### PR TITLE
Update README.md to alert about an SSL error

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ A Python interface for Minecraft built on [grpc](https://github.com/real-itu/min
 2. The first time you try to start the server a texfile eula.txt with be generated, you need to modifying its last line to `eula=true` to accept the Minecraft EULA. Now running `java -jar spongevanilla-1.12.2-7.3.0.jar` will start the server
 3. You should see a bunch of outputs including `[... INFO]: Listening on 5001`. 
 This means it's working and the Minecraft server is ready for commands on port 5001.
+
+**Note**: if you get an SSL error in step 1, try another connection (Institutions like labs can block access).
 	
 
 ### 3. Spawn blocks on the Minecraft server with Python 


### PR DESCRIPTION
Dear maintainers,

Here is a quick PR to add a note into the README to alert about an SSL error.

In fact, when I ran `java -jar spongevanilla-1.12.2-7.3.0.jar`, I got SSL error and it was due to my Lab security I guess...
I think that's important to notice this to avoid people losing too much time with this error.

Solution: I just had to change my connection (4G in my case) and everything was good! 

Here is the whole log:
`$ java -jar spongevanilla-1.12.2-7.3.0.jar`
Downloading launchwrapper-1.12.jar... This can take a while.
https://libraries.minecraft.net/net/minecraft/launchwrapper/1.12/launchwrapper-1.12.jar
Failed to download required dependencies. Please try again later.
javax.net.ssl.SSLException: Connection reset
	at sun.security.ssl.Alert.createSSLException(Alert.java:127)
	at sun.security.ssl.TransportContext.fatal(TransportContext.java:324)
	at sun.security.ssl.TransportContext.fatal(TransportContext.java:267)
	at sun.security.ssl.TransportContext.fatal(TransportContext.java:262)
	at sun.security.ssl.SSLTransport.decode(SSLTransport.java:135)
	at sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1143)
	at sun.security.ssl.SSLSocketImpl.readHandshakeRecord(SSLSocketImpl.java:1054)
	at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:394)
	at sun.net.www.protocol.https.HttpsClient.afterConnect(HttpsClient.java:559)
	at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:185)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1570)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1498)
	at sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:268)
	at java.net.URL.openStream(URL.java:1068)
	at org.spongepowered.server.launch.VanillaServerMain.downloadAndVerify(VanillaServerMain.java:232)
	at org.spongepowered.server.launch.VanillaServerMain.downloadMinecraft(VanillaServerMain.java:197)
	at org.spongepowered.server.launch.VanillaServerMain.main(VanillaServerMain.java:106)
	at org.spongepowered.server.launch.VersionCheckingMain.main(VersionCheckingMain.java:38)
	Suppressed: java.net.SocketException: Relais brisé (pipe) (Write failed)
		at java.net.SocketOutputStream.socketWrite0(Native Method)
		at java.net.SocketOutputStream.socketWrite(SocketOutputStream.java:111)
		at java.net.SocketOutputStream.write(SocketOutputStream.java:155)
		at sun.security.ssl.SSLSocketOutputRecord.encodeAlert(SSLSocketOutputRecord.java:81)
		at sun.security.ssl.TransportContext.fatal(TransportContext.java:355)
		... 16 more
Caused by: java.net.SocketException: Connection reset
	at java.net.SocketInputStream.read(SocketInputStream.java:210)
	at java.net.SocketInputStream.read(SocketInputStream.java:141)
	at sun.security.ssl.SSLSocketInputRecord.read(SSLSocketInputRecord.java:457)
	at sun.security.ssl.SSLSocketInputRecord.decode(SSLSocketInputRecord.java:165)
	at sun.security.ssl.SSLTransport.decode(SSLTransport.java:108)
	... 13 more


Best,
Kévin